### PR TITLE
Remove link to issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,6 @@
         <div class="col s12 header-input-container" id="canirequire-search">
           <input type="text" class="input-main grey-text webtask-red-border" placeholder="e.g. mongodb" name="modules-filter">
         </div>
-        <div class="center">
-          Cant't find the module you want? <a class="webtask-red-text" href="https://github.com/tehsis/webtaskio-canirequire/issues/new">Request it</a>!
-        </div>
       </div>
       <br><br>
     </div>


### PR DESCRIPTION
The issues tab has been deactivated in this repo, so when I clicked on the link it went to the 404 of Github.